### PR TITLE
Add support for sexagesimal NRES RA/Dec keywords

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,7 @@
+2.2.6
+2021-03-23
+Add support for sexagesimal NRES RA/Dec keywords
+
 2.2.5
 2021-01-07
 Remove the migrated field, remove the task queue and ability to run this as an application

--- a/ocs_ingester/utils/fits.py
+++ b/ocs_ingester/utils/fits.py
@@ -5,7 +5,8 @@ import hashlib
 import os
 
 from dateutil.parser import parse
-from astropy import wcs
+from astropy import wcs, units
+from astropy.coordinates import Angle
 
 from ocs_ingester.exceptions import DoNotRetryError
 from ocs_ingester.utils import metrics
@@ -138,7 +139,8 @@ def wcs_corners_from_dict(fits_dict):
         r = fits_dict['RADIUS']
 
         radius_in_degrees = r / 3600.0
-        ra_in_degrees = ra * 15.0
+        ra_in_degrees = Angle(ra, units.hourangle).deg
+        dec = Angle(dec, units.deg).deg
 
         c1 = (ra_in_degrees - radius_in_degrees, dec + radius_in_degrees)
         c2 = (ra_in_degrees + radius_in_degrees, dec + radius_in_degrees)

--- a/ocs_ingester/utils/fits.py
+++ b/ocs_ingester/utils/fits.py
@@ -138,7 +138,7 @@ def wcs_corners_from_dict(fits_dict):
         dec = fits_dict['DEC']
         r = fits_dict['RADIUS']
 
-        radius_in_degrees = r / 3600.0
+        radius_in_degrees = Angle(r, units.arcsecond).deg
         ra_in_degrees = Angle(ra, units.hourangle).deg
         dec = Angle(dec, units.deg).deg
 

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open(path.join(this_directory, 'README.md'), encoding='utf-8') as f:
 
 setup(
     name='ocs-ingester',
-    version='2.2.5',
+    version='2.2.6',
     description='Ingest frames into the science archive of an observatory control system',
     long_description=long_description,
     long_description_content_type='text/markdown',

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -88,6 +88,12 @@ class TestFitsUtils(unittest.TestCase):
         self.assertIn('type', result)
         self.assertIn('coordinates', result)
 
+    def test_get_wcs_corners_from_dict_for_nres_sexagesimal(self):
+        fits_dict = {'RADIUS': 5, 'RA': '11:45:44.212',  'DEC': '-80:01:44.56'}
+        result = wcs_corners_from_dict(fits_dict)
+        self.assertIn('type', result)
+        self.assertIn('coordinates', result)
+
     def test_get_wcs_corners_from_dict_for_nres_missing_headers(self):
         fits_dict = {'RADIUS': 5, 'RA': ''}
         result = wcs_corners_from_dict(fits_dict)


### PR DESCRIPTION
Now that we're running the BANZAI-NRES pipeline in dev, we have noticed that the ingester errors out when a BANZAI-NRES reduced frame has its RA and Dec in sexagesimal format, leading to the error:

`Unexpected exception: can't multiply sequence by non-int of type 'float'`

This is due to the ra keyword being a string, rather than a float.

Luckily, Astropy has the nice Angle object which can parse an angle in multiple formats and given the units it provides easy conversion functionality as well. So Curtis and I would like to propose switching this angle parsing/conversion over to using Astropy.

I have tested ingestion of a raw NRES and BANZAI-processed NRES file into http://banzai-nres-archive-api.lco.gtn using these changes and both have ingested with reasonable looking polygons, matching what is currently in the production science archive.

Curtis is going to chime in with some additional comments on how this might be improved further (maybe as a future OCS improvement) - but this fixes our issue to zeroth order.